### PR TITLE
new Component ConnectedBoxesList

### DIFF
--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -38,6 +38,11 @@ export interface AutocompleteProps<T extends {}> {
    * how to process manually entered items (not autosuggested)
    */
   findItems?: (...inputStrings: string[]) => Promise<T[]>;
+  /**
+   * You normally should not have to use this, but in special cases
+   * use className to override specific styles.
+   */
+  className?: string;
 }
 
 export const Autocomplete = <T extends {}>(props: AutocompleteProps<T>) => {

--- a/src/components/ConnectedBoxesList.spec.tsx
+++ b/src/components/ConnectedBoxesList.spec.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { cleanup } from '@testing-library/react';
+import { ContentGroup, FormRow } from '..';
+import { render } from '../test-utils';
+
+describe('<ContentGroup/>', () => {
+  afterEach(cleanup);
+
+  const title = 'test title';
+  const label = 'test label';
+  const label2 = 'test label2';
+
+  it('should render the content group component with title', () => {
+    const { getByTestId } = render(
+      <ContentGroup title={title}>
+        <div>test</div>
+      </ContentGroup>
+    );
+
+    expect(getByTestId('contentGroup-title').textContent).toEqual(title);
+  });
+
+  it('should render the content group component title tag', () => {
+    const { getByTestId } = render(
+      <ContentGroup>
+        <div data-testid="title-id">{title}</div>
+      </ContentGroup>
+    );
+
+    expect(getByTestId('title-id').textContent).toEqual(title);
+  });
+
+  it('should render content group with children items and title', () => {
+    const { getByTestId } = render(
+      <ContentGroup title={title}>
+        <FormRow>
+          <div data-testid="label1">{label}</div>
+        </FormRow>
+        <FormRow>
+          <div data-testid="label2">{label2}</div>
+        </FormRow>
+      </ContentGroup>
+    );
+
+    expect(getByTestId('label1').textContent).toEqual(label);
+    expect(getByTestId('label2').textContent).toEqual(label2);
+    expect(getByTestId('contentGroup-title').textContent).toEqual(title);
+  });
+});

--- a/src/components/ConnectedBoxesList.spec.tsx
+++ b/src/components/ConnectedBoxesList.spec.tsx
@@ -1,49 +1,112 @@
 import * as React from 'react';
 import { cleanup } from '@testing-library/react';
-import { ContentGroup, FormRow } from '..';
+import { ConnectedBoxesList } from './ConnectedBoxesList';
 import { render } from '../test-utils';
+import userEvent from '@testing-library/user-event';
 
-describe('<ContentGroup/>', () => {
+describe('<ConnectedBoxesList />', () => {
   afterEach(cleanup);
 
-  const title = 'test title';
-  const label = 'test label';
-  const label2 = 'test label2';
-
-  it('should render the content group component with title', () => {
-    const { getByTestId } = render(
-      <ContentGroup title={title}>
-        <div>test</div>
-      </ContentGroup>
+  it('should render a basic setup.', () => {
+    const { getByTestId, getAllByTestId } = render(
+      <ConnectedBoxesList
+        boxesContents={[
+          <div key={1} data-testid="content1">
+            Hello
+          </div>,
+          <div key={2} data-testid="content2">
+            Hello
+          </div>,
+        ]}
+        addButtonLabel="Hinzufügen"
+        connectBoxes
+        connectionLabel="und"
+        testId="connected-boxes"
+        onAdd={() => {}}
+        onRemove={() => {}}
+      />
     );
 
-    expect(getByTestId('contentGroup-title').textContent).toEqual(title);
+    expect(getByTestId('connected-boxes')).not.toBeNull();
+    expect(getByTestId('box-add')).not.toBeNull();
+    expect(getAllByTestId('box-remove')).toHaveLength(2);
+    expect(getAllByTestId('box-connector')).toHaveLength(2);
+    expect(getByTestId('content1')).not.toBeNull();
+    expect(getByTestId('content2')).not.toBeNull();
   });
 
-  it('should render the content group component title tag', () => {
-    const { getByTestId } = render(
-      <ContentGroup>
-        <div data-testid="title-id">{title}</div>
-      </ContentGroup>
+  it('should be able to not render the connector boxes, if disabled.', () => {
+    const { queryByTestId } = render(
+      <ConnectedBoxesList
+        boxesContents={[
+          <div key={1} data-testid="content1">
+            Hello
+          </div>,
+          <div key={2} data-testid="content2">
+            Hello
+          </div>,
+        ]}
+        addButtonLabel="Hinzufügen"
+        connectBoxes={false}
+        connectionLabel="und"
+        testId="connected-boxes"
+        onAdd={() => {}}
+        onRemove={() => {}}
+      />
     );
 
-    expect(getByTestId('title-id').textContent).toEqual(title);
+    expect(queryByTestId('box-connector')).toBeNull();
   });
 
-  it('should render content group with children items and title', () => {
-    const { getByTestId } = render(
-      <ContentGroup title={title}>
-        <FormRow>
-          <div data-testid="label1">{label}</div>
-        </FormRow>
-        <FormRow>
-          <div data-testid="label2">{label2}</div>
-        </FormRow>
-      </ContentGroup>
+  it('should render the connector boxes, if not specifically set.', () => {
+    const { queryAllByTestId } = render(
+      <ConnectedBoxesList
+        boxesContents={[
+          <div key={1} data-testid="content1">
+            Hello
+          </div>,
+          <div key={2} data-testid="content2">
+            Hello
+          </div>,
+        ]}
+        addButtonLabel="Hinzufügen"
+        connectionLabel="und"
+        testId="connected-boxes"
+        onAdd={() => {}}
+        onRemove={() => {}}
+      />
     );
 
-    expect(getByTestId('label1').textContent).toEqual(label);
-    expect(getByTestId('label2').textContent).toEqual(label2);
-    expect(getByTestId('contentGroup-title').textContent).toEqual(title);
+    expect(queryAllByTestId('box-connector')).toHaveLength(2);
+  });
+
+  it('calls the respective callbacks on click', () => {
+    const handleAddCallback = jest.fn();
+    const handleRemoveCallback = jest.fn();
+
+    const { getByTestId } = render(
+      <ConnectedBoxesList
+        boxesContents={[
+          <div key={1} data-testid="content1">
+            Hello
+          </div>,
+        ]}
+        addButtonLabel="Hinzufügen"
+        connectBoxes
+        connectionLabel="und"
+        testId="connected-boxes"
+        onAdd={handleAddCallback}
+        onRemove={handleRemoveCallback}
+      />
+    );
+
+    const addButton = getByTestId('box-add');
+    const removeButton = getByTestId('box-remove');
+
+    userEvent.click(addButton);
+    userEvent.click(removeButton);
+
+    expect(handleAddCallback).toHaveBeenCalled();
+    expect(handleRemoveCallback).toHaveBeenCalled();
   });
 });

--- a/src/components/ConnectedBoxesList.stories.tsx
+++ b/src/components/ConnectedBoxesList.stories.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+
+import {
+  ConnectedBoxesList,
+  ConnectedBoxesListProps,
+} from './ConnectedBoxesList';
+import { TextField } from './TextField';
+import { Meta, Story } from '@storybook/react';
+import { Spacer } from './Spacer';
+import { useCallback, useState } from 'react';
+
+export default {
+  title: 'Components/ConnectedBoxesList',
+  component: ConnectedBoxesList,
+} as Meta;
+
+const Template: Story<ConnectedBoxesListProps> = (props) => {
+  const [boxesContents, setBoxesContents] = useState(props.boxesContents);
+
+  const handleAdd = useCallback(() => {
+    setBoxesContents([
+      ...boxesContents,
+      <>
+        <TextField placeholder="Name" />
+        <Spacer horizontal={2} />
+        ist
+        <Spacer horizontal={2} />
+        <TextField placeholder="Adjektiv" />
+      </>,
+    ]);
+  }, [boxesContents, setBoxesContents]);
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      const newBoxesContents = [...boxesContents];
+      newBoxesContents.splice(index, 1);
+      setBoxesContents(newBoxesContents);
+    },
+    [boxesContents, setBoxesContents]
+  );
+
+  return (
+    <ConnectedBoxesList
+      boxesContents={boxesContents}
+      addButtonLabel={props.addButtonLabel}
+      connectBoxes={props.connectBoxes}
+      connectionLabel={props.connectionLabel}
+      testId={props.testId}
+      onAdd={handleAdd}
+      onRemove={handleRemove}
+    />
+  );
+};
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  boxesContents: [
+    <>
+      <TextField placeholder="Name" />
+      <Spacer horizontal={2} />
+      ist
+      <Spacer horizontal={2} />
+      <TextField placeholder="Adjektiv" />
+    </>,
+    <>
+      <TextField placeholder="Name" />
+      <Spacer horizontal={2} />
+      ist
+      <Spacer horizontal={2} />
+      <TextField placeholder="Adjektiv" />
+    </>,
+  ],
+  addButtonLabel: 'Zeile hinzufügen',
+  connectBoxes: true,
+  connectionLabel: 'und',
+  testId: 'my-grey-boxes',
+};
+
+Primary.argTypes = {
+  boxesContents: { control: null },
+  onAdd: { control: null },
+  onRemove: { control: null },
+};
+
+Primary.parameters = {
+  docs: {
+    source: {
+      type: 'code',
+    },
+  },
+};

--- a/src/components/ConnectedBoxesList.tsx
+++ b/src/components/ConnectedBoxesList.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react';
+import classNames from 'clsx';
+import { makeStyles } from '@material-ui/core';
+import { IconButton } from './IconButton';
+import { Add, Cancel } from '../icons';
+import { Button } from './Button';
+
+const useGrayBoxStyles = makeStyles((theme) => ({
+  grayBoxWrapper: {
+    position: 'relative',
+    '&:not(:last-child)': {
+      marginBottom: theme.spacing(3),
+    },
+  },
+  grayBox: {
+    display: 'flex',
+    alignItems: 'center',
+    border: '2px solid #c0c0c0',
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: '#efefef',
+    padding: `${theme.spacing(1)}px ${theme.spacing(1)}px`,
+  },
+  shortBox: {
+    display: 'inline-block',
+  },
+  buttonBoxTransform: {
+    position: 'relative',
+    width: theme.spacing(42),
+    textAlign: 'center',
+  },
+  connectorBox: {
+    position: 'absolute',
+    textAlign: 'center',
+    fontWeight: 'bold',
+    paddingTop: theme.spacing(1) / 2,
+    zIndex: 1,
+    left: theme.spacing(14),
+    bottom: theme.spacing(-3) - 2,
+    borderLeft: '2px solid #c0c0c0',
+    borderRight: '2px solid #c0c0c0',
+    backgroundColor: '#efefef',
+    width: theme.spacing(14),
+    height: theme.spacing(3) + 4,
+  },
+}));
+
+const GrayBox: React.FC<{ short?: boolean }> = ({
+  children,
+  short = false,
+}) => {
+  const classes = useGrayBoxStyles();
+  return (
+    <div className={classNames(classes.grayBox, { [classes.shortBox]: short })}>
+      {children}
+    </div>
+  );
+};
+
+export interface ConnectedBoxesListProps {
+  /**
+   * A list of components. Each element of the list will get its own row
+   * in the `ConnectedBoxesList`. A row is actually a `flex` container, so
+   * if you put multiple elements in a react fragment, they will be layed out
+   * in a 'flex' manner, e.g.:
+   * ```
+   * [<><TextField /><Spacer horizontal={2}/><TextField /></>]
+   * ```
+   */
+  boxesContents: React.ReactNode[];
+  /**
+   * The label for the button that adds a new row
+   */
+  addButtonLabel: string;
+  /**
+   * The label in the little area that connects two rows
+   */
+  connectionLabel: string;
+  /**
+   * By default, clicking on the add button will not do anything. In your
+   * implementation of the `onAdd` handler you will have to do things which
+   * should end up updating the boxesContent.
+   */
+  onAdd: VoidFunction;
+  /**
+   * By default, clicking on the remove button on any row will not do anything.
+   * In your implementation of the `onRemove` handler you will have to do things
+   * which end up updating the boxesContent. `onRemove` tells you the row index for
+   * the row the user wants removed.
+   */
+  onRemove: (index: number) => void;
+  /**
+   * Sets a `data-testid` attribute on the overall component. Note, the add button
+   * itself has a `data-testid` of 'box-add' and each remove button has a `data-testid`
+   * of 'box-remove'.
+   */
+  testId?: string;
+  /**
+   * Perhaps you just want the list of the grey boxes but you don't actually care
+   * for the connectors? Well with this little nifty boolean you can turn the
+   * whole thing off.
+   */
+  connectBoxes?: boolean;
+}
+
+/**
+ * ConnectedBoxesList was introduced to provide a way to visualize and edit
+ * logical conditions. Each row would stand for a condition, represented by
+ * individual form fields, where you can edit a condition.
+ *
+ * This component abstracts away the general visualization. It does not care
+ * for what you actually render within each row. It is totally up to you.
+ *
+ * Note that a row is a `flex` container, so you might want to take advantage
+ * of that. See the explanation at `boxesContents` for details.
+ */
+export const ConnectedBoxesList = (props: ConnectedBoxesListProps) => {
+  const classes = useGrayBoxStyles();
+  return (
+    <div data-testid={props.testId}>
+      {props.boxesContents.map((element, index) => (
+        <div key={`box-${index}`} className={classes.grayBoxWrapper}>
+          <GrayBox>
+            <IconButton
+              icon={Cancel}
+              color="default"
+              onClick={() => props.onRemove(index)}
+              data-testid="box-remove"
+            />
+            {element}
+          </GrayBox>
+          {props.connectBoxes ?? true ? (
+            <div className={classes.connectorBox}>
+              {index < props.boxesContents.length - 1
+                ? props.connectionLabel
+                : ''}
+            </div>
+          ) : null}
+        </div>
+      ))}
+      <div className={classes.buttonBoxTransform}>
+        <GrayBox short>
+          <Button
+            variant="text"
+            color="primary"
+            icon={Add}
+            data-testid="box-add"
+            onClick={props.onAdd}
+          >
+            {props.addButtonLabel}
+          </Button>
+        </GrayBox>
+      </div>
+    </div>
+  );
+};
+
+export default ConnectedBoxesList;

--- a/src/components/ConnectedBoxesList.tsx
+++ b/src/components/ConnectedBoxesList.tsx
@@ -129,7 +129,7 @@ export const ConnectedBoxesList = (props: ConnectedBoxesListProps) => {
             {element}
           </GrayBox>
           {props.connectBoxes ?? true ? (
-            <div className={classes.connectorBox}>
+            <div className={classes.connectorBox} data-testid="box-connector">
               {index < props.boxesContents.length - 1
                 ? props.connectionLabel
                 : ''}

--- a/src/components/SelectField.tsx
+++ b/src/components/SelectField.tsx
@@ -65,6 +65,11 @@ export interface SelectFieldProps {
    * The value of the input element that is set per default.
    */
   defaultValue?: TextFieldValue;
+  /**
+   * You normally should not have to use this, but in special cases
+   * use className to override specific styles.
+   */
+  className?: string;
 }
 
 /**

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -135,6 +135,11 @@ export interface TextFieldProps {
    * @default primary
    */
   color?: TextFieldColor;
+  /**
+   * You normally should not have to use this, but in special cases
+   * use className to override specific styles.
+   */
+  className?: string;
 }
 
 const useInputStyles = makeStyles<Theme, { color: TextFieldColor }>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './components/AppBar';
 export * from './components/Button';
 export * from './components/ButtonBar';
 export * from './components/ConfirmationDialog';
+export * from './components/ConnectedBoxesList';
 export * from './components/ContentGroup';
 export * from './components/DateField';
 export * from './components/DatePicker';


### PR DESCRIPTION
After a chat with @schapka we decided to add this component to the backoffice-ui.

![image](https://user-images.githubusercontent.com/1169512/129059366-ae215013-0fb1-47e6-a312-d83c74b37623.png)

ConnectedBoxesList was introduced to provide a way to visualize and edit logical conditions. Each row would stand for a condition, represented by individual form fields, where you can edit a condition.

This component abstracts away the general visualization. It does not care for what you actually render within each row. It is totally up to you.

Additionally I also discussed with René, that for some exisiting components, we need the ability to set override css classes in order to make them work visually in special situations. Those are Autcomplete, SelectField and TextField.