### PR TITLE
feat: make autocomplete label optional, as it is in TextField

### DIFF
--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -8,7 +8,7 @@ export interface AutocompleteProps<T extends {}> {
   /**
    * The label of this autocomplete field that will be shown inside when empty and not focused, inside the top line when filled.
    */
-  label: string;
+  label?: string;
   /**
    * The inputPlaceholder is shown inside the input while typing as a suggestion
    */


### PR DESCRIPTION
I would like to use the AutoComplete component without the label. The component (namely its TextField) is already able to do it, but the prop types didn't allow it.