### PR TITLE
Add hideAddButton to ConnectedBoxesList

### DIFF
--- a/src/components/ConnectedBoxesList.spec.tsx
+++ b/src/components/ConnectedBoxesList.spec.tsx
@@ -58,6 +58,29 @@ describe('<ConnectedBoxesList />', () => {
     expect(queryByTestId('box-connector')).toBeNull();
   });
 
+  it('should be able to not render the add button, if disabled.', () => {
+    const { queryAllByTestId } = render(
+      <ConnectedBoxesList
+        boxesContents={[
+          <div key={1} data-testid="content1">
+            Hello
+          </div>,
+          <div key={2} data-testid="content2">
+            Hello
+          </div>,
+        ]}
+        addButtonLabel="Hinzufügen"
+        connectionLabel="und"
+        testId="connected-boxes"
+        onAdd={() => {}}
+        onRemove={() => {}}
+        hideAddButton
+      />
+    );
+
+    expect(queryAllByTestId('box-connector')).toHaveLength(1);
+  });
+
   it('should render the connector boxes, if not specifically set.', () => {
     const { queryAllByTestId } = render(
       <ConnectedBoxesList

--- a/src/components/ConnectedBoxesList.spec.tsx
+++ b/src/components/ConnectedBoxesList.spec.tsx
@@ -59,7 +59,7 @@ describe('<ConnectedBoxesList />', () => {
   });
 
   it('should be able to not render the add button, if disabled.', () => {
-    const { queryAllByTestId } = render(
+    const { queryAllByTestId, queryByTestId } = render(
       <ConnectedBoxesList
         boxesContents={[
           <div key={1} data-testid="content1">
@@ -79,6 +79,7 @@ describe('<ConnectedBoxesList />', () => {
     );
 
     expect(queryAllByTestId('box-connector')).toHaveLength(1);
+    expect(queryByTestId('box-add')).toBeNull();
   });
 
   it('should render the connector boxes, if not specifically set.', () => {

--- a/src/components/ConnectedBoxesList.stories.tsx
+++ b/src/components/ConnectedBoxesList.stories.tsx
@@ -45,6 +45,7 @@ const Template: Story<ConnectedBoxesListProps> = (props) => {
       addButtonLabel={props.addButtonLabel}
       connectBoxes={props.connectBoxes}
       connectionLabel={props.connectionLabel}
+      hideAddButton={props.hideAddButton}
       testId={props.testId}
       onAdd={handleAdd}
       onRemove={handleRemove}

--- a/src/components/ConnectedBoxesList.tsx
+++ b/src/components/ConnectedBoxesList.tsx
@@ -100,6 +100,11 @@ export interface ConnectedBoxesListProps {
    * whole thing off.
    */
   connectBoxes?: boolean;
+  /**
+   * Sometimes enough is enough. You don't want your users to add even more boxes and drown
+   * in it. Just flip this switch and the add button disappears.
+   */
+  hideAddButton?: boolean;
 }
 
 /**
@@ -128,7 +133,8 @@ export const ConnectedBoxesList = (props: ConnectedBoxesListProps) => {
             />
             {element}
           </GrayBox>
-          {props.connectBoxes ?? true ? (
+          {(props.connectBoxes ?? true) &&
+          (!props.hideAddButton || index < props.boxesContents.length - 1) ? (
             <div className={classes.connectorBox} data-testid="box-connector">
               {index < props.boxesContents.length - 1
                 ? props.connectionLabel
@@ -137,19 +143,21 @@ export const ConnectedBoxesList = (props: ConnectedBoxesListProps) => {
           ) : null}
         </div>
       ))}
-      <div className={classes.buttonBoxTransform}>
-        <GrayBox short>
-          <Button
-            variant="text"
-            color="primary"
-            icon={Add}
-            data-testid="box-add"
-            onClick={props.onAdd}
-          >
-            {props.addButtonLabel}
-          </Button>
-        </GrayBox>
-      </div>
+      {props.hideAddButton ?? false ? null : (
+        <div className={classes.buttonBoxTransform}>
+          <GrayBox short>
+            <Button
+              variant="text"
+              color="primary"
+              icon={Add}
+              data-testid="box-add"
+              onClick={props.onAdd}
+            >
+              {props.addButtonLabel}
+            </Button>
+          </GrayBox>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
We have situations, where we do not want to allow to add more boxes in the ConnectedBoxesList. This PR introduces a switch to hide the add button temporarily.