### PR TITLE
feat: add default order props to EnhancedDataTable

### DIFF
--- a/src/components/EnhancedDataTable/EnhancedDataTable.spec.tsx
+++ b/src/components/EnhancedDataTable/EnhancedDataTable.spec.tsx
@@ -455,6 +455,21 @@ describe('<EnhancedDataTable />', () => {
     expect(fetchDataFn.mock.calls[3][0].orderBy).toBe(columns[2].accessor);
   });
 
+  it('should be possible to provide default sorting for data fetching', async () => {
+    const { getByTestId } = render(
+      <EnhancedDataTable
+        columns={columns}
+        fetchData={fetchDataFn}
+        defaultOrder="desc"
+        defaultOrderBy={columns[1].accessor}
+      />
+    );
+    await waitFor(() => {});
+    expect(fetchDataFn).toHaveBeenCalledTimes(1);
+    expect(fetchDataFn.mock.calls[0][0].order).toBe('desc');
+    expect(fetchDataFn.mock.calls[0][0].orderBy).toBe(columns[1].accessor);
+  });
+
   it('should be possible to set and unset a text filter on a given column', async () => {
     const filters: Array<Filter<TestData>> = [
       {

--- a/src/components/EnhancedDataTable/EnhancedDataTable.tsx
+++ b/src/components/EnhancedDataTable/EnhancedDataTable.tsx
@@ -85,6 +85,15 @@ export interface EnhancedDataTableProps<D extends object> {
    */
   fetchData: EnhancedDataTableFetchData<D>;
   /**
+   * If provided sets the default order for data fetching. Possible values include 'asc' and 'desc'.
+   * It's default is 'asc'.
+   */
+  defaultOrder?: Order;
+  /**
+   * If provided sets the default order criterion for data fetching. Possibly includes all keys of D.
+   */
+  defaultOrderBy?: keyof D;
+  /**
    * List of available (and initially active) filters.
    * You can activate a given filter initially by setting its value property.
    */
@@ -232,6 +241,8 @@ export function EnhancedDataTable<D extends object>(
     columns,
     filters,
     fetchData,
+    defaultOrder = 'asc',
+    defaultOrderBy,
     selectionActions = [],
     onRowClick,
     defaultPageSize = 10,
@@ -265,8 +276,10 @@ export function EnhancedDataTable<D extends object>(
       totalCount: 0,
     }
   );
-  const [order, setOrder] = React.useState<Order>('asc');
-  const [orderBy, setOrderBy] = React.useState<keyof D>();
+  const [order, setOrder] = React.useState<Order>(defaultOrder);
+  const [orderBy, setOrderBy] = React.useState<keyof D | undefined>(
+    defaultOrderBy
+  );
   const tableRef = React.useRef<HTMLDivElement>(null);
   const isAllRowsSelected = !!data && selectedRows.length === data.length;
   const classes = useStyles();


### PR DESCRIPTION
This change is supposed to introduced default order props to the EnhancedDataTable and should be fully backwards compatible.